### PR TITLE
Add end() method and mode change validation

### DIFF
--- a/src/STC3100dd.cpp
+++ b/src/STC3100dd.cpp
@@ -51,7 +51,8 @@ bool STC3100dd::start(){
     
     //Reset Charge Acc to 0
     resetChargeAcc();
-
+    //Set Operating mode and resolution
+    setModeOperateRun();
     updateModeReg();
 
     #if defined STC3100DD_DEBUG
@@ -66,6 +67,33 @@ bool STC3100dd::start(){
     #endif // STC3100DD_DEBUG
 
     return true;
+}
+
+void STC3100dd::end(){
+    #if defined STC3100DD_DEBUG
+    uint16_t reg = getReadingWire(STC3100_REG_MODE);
+    uint8_t lo = reg & 0xFF;
+    uint8_t hi = (reg >> 8) & 0xFF;
+    Serial.print("STC3100dd STC3100_REG_MODE 0x");
+    Serial.println(lo, HEX);
+    Serial.print("STC3100dd STC3100_REG_CTRL 0x");
+    Serial.println(hi, HEX);
+    #endif // STC3100DD_DEBUG
+
+    //Set Standby mode
+    setModeOperateStandby();
+    updateModeReg();
+
+    #if defined STC3100DD_DEBUG
+    reg = getReadingWire(STC3100_REG_MODE);
+    lo = reg & 0xFF;
+    hi = (reg >> 8) & 0xFF;
+    Serial.println("STC3100dd After deinitCTL");    
+    Serial.print("STC3100dd STC3100_REG_MODE 0x");
+    Serial.println(lo, HEX);
+    Serial.print("STC3100dd STC3100_REG_CTRL 0x");
+    Serial.println(hi, HEX);
+    #endif // STC3100DD_DEBUG
 }
 
 String STC3100dd::getSn(void)   {

--- a/src/STC3100dd.h
+++ b/src/STC3100dd.h
@@ -147,14 +147,15 @@ class STC3100dd
  * If the serial number can be read and confirmed, this function will set the
  * chip to start taking readings.
  * 
- * @return true When serial is read and confirmed else false
+ * @return true When serial is read, operating mode set and confirmed else false
  */
   bool start();
   /**
  * @brief end() will put sensor to standby mode
  * 
+ * @return true When standby mode set and confirmed else false
  */
-  void end();
+  bool end();
 
   void    setAdcResolution(uint8_t adc_resolution=STC3100_REG_MODE_ADCRES_14BITS);
   uint8_t getAdcResolution() {return _adc_resolution;}

--- a/src/STC3100dd.h
+++ b/src/STC3100dd.h
@@ -150,6 +150,11 @@ class STC3100dd
  * @return true When serial is read and confirmed else false
  */
   bool start();
+  /**
+ * @brief end() will put sensor to standby mode
+ * 
+ */
+  void end();
 
   void    setAdcResolution(uint8_t adc_resolution=STC3100_REG_MODE_ADCRES_14BITS);
   uint8_t getAdcResolution() {return _adc_resolution;}
@@ -329,7 +334,7 @@ The temperature of 0° C corresponds to code 0.
 
   uint16_t _current_resistor_milliohms = STC3100_R_SERIES_mOhms;
   uint8_t _adc_resolution = 0;
-  bool _operate = true;
+  bool _operate = false;
   bool _detectedPresent = false;
 
   /**


### PR DESCRIPTION
Hi, we've been doing some more development, though it's worth sharing :)

I've implemented the `STC3100dd::end()` for setting sensor standby mode in a single call and modified `start()` to explicitly call `setModeOperateRun()` so then `_operate` reflects the current sensor state.
Also added mode register readout after writing inside `updateModeReg()` so that both `start()` and `end()` can verify the run bit actually flipped and that is reflected in their return code.